### PR TITLE
CM-124 Fix network interface in config toml

### DIFF
--- a/docker/blz-setup.sh
+++ b/docker/blz-setup.sh
@@ -2,6 +2,7 @@
 
 if [ "$NODE_NAME" = "swarm01" ]; then
   tar xvf ./blz-test.tar.xz
+  sed -i -e 's/127.0.0.1:26657/0.0.0.0:26657/g' .blzd/config/config.toml
   blzd start &
   sleep 5s
   blzcli rest-server --laddr tcp://0.0.0.0:1317
@@ -12,6 +13,7 @@ else
   blzcli config indent true
   blzcli config trust-node true
   tar -xf blz-test.tar.xz .blzd/config/genesis.json
+  sed -i -e 's/127.0.0.1:26657/0.0.0.0:26657/g' .blzd/config/config.toml
   sed -i -e 's/minimum-gas-prices = ""/minimum-gas-prices = "0.01bnt"/g' .blzd/config/app.toml
   NODE_ID=$(cat .blzd/config/genesis.json | grep \"memo\" | awk -F'[@|:|\"]' '{print $5}')@${LOCAL_IP}:26656
   blzd start --p2p.persistent_peers ${NODE_ID}


### PR DESCRIPTION
Super quick fix for config toml during docker deploy. Network interface needs to be set to 0.0.0.0:26657 rather than 127.0.0.1:26657 in order for the blzcli to communicate with it.