### PR TITLE
Tax Module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ go.sum: go.mod
 test:
 	@go test -mod=readonly $(PACKAGES)
 
+test-tax:
+	@go test -mod=readonly ./x/tax/...
+
 coverage:
 	@go test -v -coverprofile=$(coverage) ./x/...
 	@go tool cover -html=$(coverage)

--- a/app/test_common.go
+++ b/app/test_common.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	tmdb "github.com/tendermint/tm-db"
+
+	"github.com/tendermint/tendermint/libs/log"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+	"github.com/cosmos/cosmos-sdk/x/distribution"
+	"github.com/cosmos/cosmos-sdk/x/gov"
+	"github.com/cosmos/cosmos-sdk/x/params"
+	"github.com/cosmos/cosmos-sdk/x/slashing"
+	"github.com/cosmos/cosmos-sdk/x/staking"
+	"github.com/cosmos/cosmos-sdk/x/supply"
+
+	bluzellechain "github.com/bluzelle/curium/types"
+	"github.com/bluzelle/curium/x/tax"
+)
+
+// TestApp is a simple wrapper around an App. It exposes internal keepers for use in integration tests.
+// This file also contains test helpers. Ideally they would be in separate package.
+// Basic Usage:
+// 	Create a test app with NewTestApp, then all keepers and their methods can be accessed for test setup and execution.
+// Advanced Usage:
+// 	Some tests call for an app to be initialized with some state. This can be achieved through keeper method calls (ie keeper.SetParams(...)).
+// 	However this leads to a lot of duplicated logic similar to InitGenesis methods.
+// 	So TestApp.InitializeFromGenesisStates() will call InitGenesis with the default genesis state.
+//	and TestApp.InitializeFromGenesisStates(authState, cdpState) will do the same but overwrite the auth and cdp sections of the default genesis state
+// 	Creating the genesis states can be combersome, but helper methods can make it easier such as NewAuthGenStateFromAccounts below.
+type TestApp struct {
+	CRUDApp
+}
+
+func NewTestApp() TestApp {
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount(bluzellechain.Bech32PrefixAccAddr, bluzellechain.Bech32PrefixAccPub)
+	config.SetBech32PrefixForValidator(bluzellechain.Bech32PrefixValAddr, bluzellechain.Bech32PrefixValPub)
+	config.SetBech32PrefixForConsensusNode(bluzellechain.Bech32PrefixConsAddr, bluzellechain.Bech32PrefixConsPub)
+
+	db := tmdb.NewMemDB()
+	app := NewCRUDApp(log.NewNopLogger(), db)
+	return TestApp{CRUDApp: *app}
+}
+
+// nolint
+func (tApp TestApp) GetAccountKeeper() auth.AccountKeeper { return tApp.accountKeeper }
+func (tApp TestApp) GetBankKeeper() bank.Keeper           { return tApp.bankKeeper }
+func (tApp TestApp) GetSupplyKeeper() supply.Keeper       { return tApp.supplyKeeper }
+func (tApp TestApp) GetStakingKeeper() staking.Keeper     { return tApp.stakingKeeper }
+func (tApp TestApp) GetSlashingKeeper() slashing.Keeper   { return tApp.slashingKeeper }
+func (tApp TestApp) GetDistrKeeper() distribution.Keeper  { return tApp.distrKeeper }
+func (tApp TestApp) GetGovKeeper() gov.Keeper             { return tApp.govKeeper }
+func (tApp TestApp) GetParamsKeeper() params.Keeper       { return tApp.paramsKeeper }
+func (tApp TestApp) GetTaxKeeper() tax.Keeper             { return tApp.taxKeeper }

--- a/cmd/blzcli/main.go
+++ b/cmd/blzcli/main.go
@@ -15,11 +15,12 @@
 package main
 
 import (
-	"github.com/cosmos/cosmos-sdk/client/flags"
 	"os"
 	"path"
 
-	app "github.com/bluzelle/curium"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+
+	"github.com/bluzelle/curium/app"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/client/lcd"

--- a/cmd/blzd/main.go
+++ b/cmd/blzd/main.go
@@ -40,7 +40,7 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 	dbm "github.com/tendermint/tm-db"
 
-	app "github.com/bluzelle/curium"
+	"github.com/bluzelle/curium/app"
 )
 
 func main() {

--- a/localsetup.sh
+++ b/localsetup.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+rm -rf ~/.blzd
+rm -rf ~/.blzcli
+
+blzd init masternode --chain-id blzchain
+blzcli config chain-id blzchain
+blzcli config output json
+blzcli config indent true
+blzcli config trust-node true
+
+blzcli keys add node0 --keyring-backend=test --recover <<< "cat indoor zoo vivid actress steak female fat shrug payment harvest sadness hazard frown alcohol mountain erode latin symbol peace repair inspire blade supply"
+blzd add-genesis-account $(blzcli keys show node0 -a --keyring-backend=test) 1000000000stake
+
+blzd gentx --name node0 --keyring-backend=test
+blzd collect-gentxs
+blzd start
+
+## try sending with genesis configuration ##
+# blzcli keys add user1 --keyring-backend=test
+# blzcli tx bank send node0 $(blzcli keys show -a user1  --keyring-backend=test) 10000stake --keyring-backend=test --fees=1000stake
+# blzcli query account bluzelle1wjkdcz4hl4gcarnqtupu7vkftal6h34qxjh6rw
+# expected result: 11stake
+# blzcli tx send node0 $(blzcli keys show -a user1  --keyring-backend=test) 10000stake  --keyring-backend=test --fees=1000stake
+# blzcli query account bluzelle1wjkdcz4hl4gcarnqtupu7vkftal6h34qxjh6rw
+# expected result: 22stake
+# blzcli query tax info
+
+## create tax_owner key on local ##
+# blzcli keys add tax_owner --recover --keyring-backend=test
+# day rabbit mom clown bleak brown large lobster reduce accuse violin where address click dynamic myself buyer daughter situate today wheel thumb sudden drill
+
+## try tax param change with wrong account ##
+# blzcli tx tax set-bp 10 20 --from node0 --keyring-backend=test
+# blzcli query tax info 
+# blzcli tx tax set-collector $(blzcli keys show -a user1 --keyring-backend=test) --from node0 --keyring-backend=test
+# blzcli query tax info 
+
+## try tax param change with correct account ##
+# blzcli tx tax set-bp 30 40 --from tax_owner --keyring-backend=test
+# blzcli query tax info 
+# blzcli tx tax set-collector $(blzcli keys show -a user1 --keyring-backend=test) --from tax_owner --keyring-backend=test
+# blzcli query tax info 
+
+## try bank send with modified params ##
+# blzcli tx bank send node0 $(blzcli keys show -a user1  --keyring-backend=test) 10000stake --keyring-backend=test --fees=1000stake
+# blzcli query account $(blzcli keys show -a user1 --keyring-backend=test)
+# expected result: 20043stake
+
+# blzcli keys add user1 --keyring-backend=test
+# blzcli tx send node0 $(blzcli keys show -a user1 --keyring-backend=test) 10000000stake --gas-prices 0.0002stake --keyring-backend=test --yes
+
+## set tax owner back to original ##
+# blzcli tx tax set-collector $(blzcli keys show -a tax_owner --keyring-backend=test) --from user1 --keyring-backend=test
+# blzcli query tax info 
+
+############ negatives testing #################
+
+## Transfer taxes are not being charged on create-validator (you bond an amount as part of this) ## $(blzd tendermint show-validator)
+# blzcli keys add nval --keyring-backend=test
+# blzcli tx bank send node0 $(blzcli keys show -a nval --keyring-backend=test) 1000000stake --keyring-backend=test --fees=1000stake
+# blzcli query account bluzelle1wjkdcz4hl4gcarnqtupu7vkftal6h34qxjh6rw
+# blzcli tx staking create-validator --amount=10000stake --moniker="nval" --pubkey=bluzellevalconspub1zcjduepqladdfp8vrmpjwm7e0pcvxg34qk0uh0fd9sqtakduzm6dhqd5zmhsv285xk --commission-rate="0.10" --commission-max-rate="0.20" --commission-max-change-rate="0.01" --min-self-delegation="1" --gas="auto" --gas-prices="0.025stake" --from nval --keyring-backend=test
+# blzcli query account bluzelle1wjkdcz4hl4gcarnqtupu7vkftal6h34qxjh6rw
+
+## Transfer taxes are not being charged on delegations (self or not) ## $(blzcli q staking validators)
+# VALADDR=$(blzcli query staking validators | sed -n 's/\"operator_address\": \"\(bluzellevaloper.*\)\".*/\1/p')
+# echo $VALADDR
+# blzcli query account bluzelle1wjkdcz4hl4gcarnqtupu7vkftal6h34qxjh6rw
+# blzcli tx staking delegate $VALADDR 10000stake --from nval --keyring-backend=test --yes
+# blzcli query account bluzelle1wjkdcz4hl4gcarnqtupu7vkftal6h34qxjh6rw
+
+## Transfer taxes are not being charged on governance submit-proposal (that also takes an initial deposit) ##
+# blzcli query account bluzelle1wjkdcz4hl4gcarnqtupu7vkftal6h34qxjh6rw
+# blzcli tx gov submit-proposal --title="Test Proposal" --description="My awesome proposal" --type="Text" --deposit="10000stake" --from nval --keyring-backend=test
+# blzcli query account bluzelle1wjkdcz4hl4gcarnqtupu7vkftal6h34qxjh6rw
+
+## Transfer taxes are not being charged on governance deposits ##
+# blzcli query account bluzelle1wjkdcz4hl4gcarnqtupu7vkftal6h34qxjh6rw
+# blzcli tx gov deposit 1 10000stake --from node0 --keyring-backend=test --yes
+# blzcli query account bluzelle1wjkdcz4hl4gcarnqtupu7vkftal6h34qxjh6rw

--- a/x/tax/README.md
+++ b/x/tax/README.md
@@ -1,0 +1,24 @@
+# Readme 
+
+Tax module is for customization of fees flow.
+
+DeductFee ante handler is sending specified bp(basis point, unit of `0.0001`) of fee to the address specified by tax module.
+And rest of them are sent to fee collector module as it was doing.
+
+# Queries
+
+Query command query tax collector (owner) and fee tax bp and transfer tax bp.
+```sh
+blzcli query tax info 
+```
+
+# Transactions
+
+Set tax fee bp and transfer tax bp.
+```sh
+blzcli tx tax set-bp 30 40 --from tax_owner --keyring-backend=test
+blzcli tx tax set-collector $(blzcli keys show -a user1 --keyring-backend=test) --from tax_owner --keyring-backend=test
+```
+# Command to run test
+
+Go to root directory of project and run `make test-tax`.

--- a/x/tax/alias.go
+++ b/x/tax/alias.go
@@ -1,0 +1,26 @@
+package tax
+
+import (
+	"github.com/bluzelle/curium/x/tax/internal/keeper"
+	"github.com/bluzelle/curium/x/tax/internal/types"
+)
+
+// constants
+var (
+	ModuleName = types.ModuleName
+	RouterKey  = types.RouterKey
+	StoreKey   = types.StoreKey
+)
+
+// modules
+var (
+	NewKeeper     = keeper.NewKeeper
+	NewQuerier    = keeper.NewQuerier
+	ModuleCdc     = types.ModuleCdc
+	RegisterCodec = types.RegisterCodec
+)
+
+// Keeper alias types
+type (
+	Keeper = keeper.Keeper
+)

--- a/x/tax/ante/ante.go
+++ b/x/tax/ante/ante.go
@@ -1,0 +1,156 @@
+package ante
+
+import (
+	"github.com/bluzelle/curium/x/tax"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	"github.com/cosmos/cosmos-sdk/x/auth/exported"
+	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	bank "github.com/cosmos/cosmos-sdk/x/bank"
+	"github.com/cosmos/cosmos-sdk/x/gov/types"
+)
+
+func NewAnteHandler(
+	ak keeper.AccountKeeper,
+	bk bank.Keeper,
+	supplyKeeper types.SupplyKeeper,
+	tk tax.Keeper,
+	sigGasConsumer ante.SignatureVerificationGasConsumer,
+) sdk.AnteHandler {
+	return sdk.ChainAnteDecorators(
+		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
+		ante.NewMempoolFeeDecorator(),
+		ante.NewValidateBasicDecorator(),
+		ante.NewValidateMemoDecorator(ak),
+		ante.NewConsumeGasForTxSizeDecorator(ak),
+		ante.NewSetPubKeyDecorator(ak), // SetPubKeyDecorator must be called before all signature verification decorators
+		ante.NewValidateSigCountDecorator(ak),
+		ante.NewDeductFeeDecorator(ak, supplyKeeper),
+		NewDeductFeeDecorator(ak, supplyKeeper, tk, bk),
+		ante.NewSigGasConsumeDecorator(ak, sigGasConsumer),
+		ante.NewSigVerificationDecorator(ak),
+		ante.NewIncrementSequenceDecorator(ak), // innermost AnteDecorator
+	)
+}
+
+type DeductFeeDecorator struct {
+	ak           keeper.AccountKeeper
+	bk           bank.Keeper
+	tk           tax.Keeper
+	supplyKeeper types.SupplyKeeper
+}
+
+func NewDeductFeeDecorator(ak keeper.AccountKeeper, sk types.SupplyKeeper, tk tax.Keeper, bk bank.Keeper) DeductFeeDecorator {
+	return DeductFeeDecorator{
+		ak:           ak,
+		supplyKeeper: sk,
+		tk:           tk,
+		bk:           bk,
+	}
+}
+
+// FeeTx defines the interface to be implemented by Tx to use the FeeDecorators
+type FeeTx interface {
+	sdk.Tx
+	GetGas() uint64
+	GetFee() sdk.Coins
+	FeePayer() sdk.AccAddress
+}
+
+func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	feeTx, ok := tx.(FeeTx)
+	if !ok {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+	}
+
+	feePayer := feeTx.FeePayer()
+	feePayerAcc := dfd.ak.GetAccount(ctx, feePayer)
+
+	if feePayerAcc == nil {
+		return ctx, sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "fee payer address: %s does not exist", feePayer)
+	}
+
+	// deduct the fees
+	if !feeTx.GetFee().IsZero() {
+		taxInfo := dfd.tk.GetTaxInfo(ctx)
+
+		// handle bank send tx fee
+		msgs := tx.GetMsgs()
+		for _, msg := range msgs {
+			if msg.Type() == "send" {
+				bankmsg := msg.(bank.MsgSend)
+				trfFees := sdk.Coins{}
+				for _, coin := range bankmsg.Amount {
+					feeAmt := coin.Amount.Int64() * taxInfo.TransferBp / 10000
+					if feeAmt < 1 {
+						feeAmt = 1
+					}
+
+					trfFee := sdk.NewInt64Coin(coin.Denom, feeAmt)
+					trfFees = append(trfFees, trfFee)
+				}
+
+				if err := dfd.bk.SendCoins(ctx, feePayer, taxInfo.Collector, trfFees); err != nil {
+					return ctx, err
+				}
+			}
+		}
+
+		err = deductFees(dfd.supplyKeeper, ctx, feePayerAcc, taxInfo.Collector, feeTx.GetFee(), taxInfo.FeeBp)
+		if err != nil {
+			return ctx, err
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+func deductFees(supplyKeeper types.SupplyKeeper, ctx sdk.Context, acc exported.Account, toAcc sdk.AccAddress, fees sdk.Coins, feebp int64) error {
+	blockTime := ctx.BlockHeader().Time
+	coins := acc.GetCoins()
+
+	if !fees.IsValid() {
+		return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFee, "invalid fee amount: %s", fees)
+	}
+
+	// verify the account has enough funds to pay for fees
+	_, hasNeg := coins.SafeSub(fees)
+	if hasNeg {
+		return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFunds,
+			"insufficient funds to pay for fees; %s < %s", coins, fees)
+	}
+
+	// Validate the account has enough "spendable" coins...
+	spendableCoins := acc.SpendableCoins(blockTime)
+
+	taxFees := sdk.Coins{}
+	for _, fee := range fees {
+		feeAmt := fee.Amount.Int64() * feebp / 10000
+		if feeAmt < 1 {
+			feeAmt = 1
+		}
+		taxFee := sdk.NewInt64Coin(fee.Denom, feeAmt)
+		taxFees = append(taxFees, taxFee)
+	}
+
+	if _, hasNeg := spendableCoins.SafeSub(taxFees); hasNeg {
+		return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFunds,
+			"insufficient funds to pay for tax fees; %s < %s", spendableCoins, taxFees)
+	}
+
+	err := supplyKeeper.SendCoinsFromAccountToModule(ctx, acc.GetAddress(), authtypes.FeeCollectorName, fees)
+	if err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFunds, err.Error())
+	}
+
+	if !taxFees.Empty() {
+		err = supplyKeeper.SendCoinsFromModuleToAccount(ctx, authtypes.FeeCollectorName, toAcc, taxFees)
+		if err != nil {
+			return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFunds, err.Error())
+		}
+	}
+
+	return nil
+}

--- a/x/tax/ante/ante_test.go
+++ b/x/tax/ante/ante_test.go
@@ -1,0 +1,1 @@
+package ante

--- a/x/tax/client/cli/query.go
+++ b/x/tax/client/cli/query.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/bluzelle/curium/x/tax/internal/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/spf13/cobra"
+)
+
+// GetQueryCmd returns module query commands
+func GetQueryCmd(storeKey string, cdc *codec.Codec) *cobra.Command {
+	taxQueryCmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      "Querying commands for the tax module",
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 0,
+		RunE:                       client.ValidateCmd,
+	}
+
+	taxQueryCmd.AddCommand(flags.GetCommands(
+		GetCmdQTaxInfo(storeKey, cdc),
+	)...)
+
+	return taxQueryCmd
+}
+
+// GetCmdQTaxInfo returns tax info by query
+func GetCmdQTaxInfo(queryRoute string, cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "info",
+		Short: "show tax info",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/tax_info", queryRoute), nil)
+
+			if err != nil {
+				fmt.Println("could get tax info ", err)
+				return nil
+			}
+
+			var out types.TaxInfo
+			cdc.MustUnmarshalJSON(res, &out)
+			return cliCtx.PrintOutput(out)
+		},
+	}
+}

--- a/x/tax/client/cli/tx.go
+++ b/x/tax/client/cli/tx.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"bufio"
+	"strconv"
+
+	"github.com/bluzelle/curium/x/tax/internal/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
+	"github.com/spf13/cobra"
+)
+
+func GetTxCmd(_ string, cdc *codec.Codec) *cobra.Command {
+	taxTxCmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      "tax transaction subcommands",
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+	taxTxCmd.AddCommand(flags.PostCommands(
+		GetCmdSetCollector(cdc),
+		GetCmdSetBp(cdc),
+	)...)
+
+	return taxTxCmd
+}
+
+func GetCmdSetCollector(cdc *codec.Codec) *cobra.Command {
+	cc := cobra.Command{
+		Use:   "set-collector [address]",
+		Short: "set collector of tax module",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			inBuf := bufio.NewReader(cmd.InOrStdin())
+			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
+
+			collector, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgSetCollector(collector, cliCtx.GetFromAddress())
+
+			err = msg.ValidateBasic()
+			if err != nil {
+				return err
+			}
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
+		},
+	}
+
+	return &cc
+}
+
+func GetCmdSetBp(cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "set-bp [fee_bp] [transfer_bp]",
+		Short: "set basis point (0.0001 unit) of tax",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			inBuf := bufio.NewReader(cmd.InOrStdin())
+			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
+
+			feebp, err := strconv.Atoi(args[0])
+			if err != nil {
+				return err
+			}
+
+			trfbp, err := strconv.Atoi(args[1])
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgSetBp(int64(feebp), int64(trfbp), cliCtx.GetFromAddress())
+
+			err = msg.ValidateBasic()
+			if err != nil {
+				return err
+			}
+
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
+		},
+	}
+}

--- a/x/tax/client/rest/query.go
+++ b/x/tax/client/rest/query.go
@@ -1,0 +1,23 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/types/rest"
+	"github.com/gorilla/mux"
+)
+
+func QueryTaxInfoHandler(cliCtx context.CLIContext, storeName string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+
+		res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/read/%s/%s", storeName, vars["UUID"], vars["key"]), nil)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusNotFound, err.Error())
+			return
+		}
+		rest.PostProcessResponse(w, cliCtx, res)
+	}
+}

--- a/x/tax/client/rest/rest.go
+++ b/x/tax/client/rest/rest.go
@@ -1,0 +1,15 @@
+package rest
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/gorilla/mux"
+)
+
+// RegisterRoutes - Central function to define routes that get registered by the main application
+func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) {
+	r.HandleFunc(fmt.Sprintf("/%s/into", storeName), QueryTaxInfoHandler(cliCtx, storeName)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/bp", storeName), SetBpHandler(cliCtx)).Methods("POST")
+	r.HandleFunc(fmt.Sprintf("/%s/collector", storeName), SetCollectorHandler(cliCtx)).Methods("POST")
+}

--- a/x/tax/client/rest/tx.go
+++ b/x/tax/client/rest/tx.go
@@ -1,0 +1,93 @@
+package rest
+
+import (
+	"net/http"
+
+	"github.com/bluzelle/curium/x/tax/internal/types"
+	"github.com/cosmos/cosmos-sdk/client/context"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/rest"
+	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
+)
+
+type setCollectorReq struct {
+	BaseReq   rest.BaseReq
+	Collector string
+	Proposer  string
+}
+
+func SetCollectorHandler(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req setCollectorReq
+
+		if !rest.ReadRESTReq(w, r, cliCtx.Codec, &req) {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, "failed to parse request")
+			return
+		}
+
+		baseReq := req.BaseReq.Sanitize()
+		if !baseReq.ValidateBasic(w) {
+			return
+		}
+
+		proposer, err := sdk.AccAddressFromBech32(req.Proposer)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		collector, err := sdk.AccAddressFromBech32(req.Collector)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		msg := types.NewMsgSetCollector(collector, proposer)
+		err = msg.ValidateBasic()
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		utils.WriteGenerateStdTxResponse(w, cliCtx, baseReq, []sdk.Msg{msg})
+	}
+}
+
+type setBpReq struct {
+	BaseReq    rest.BaseReq
+	FeeBp      int
+	TransferBp int
+	Proposer   string
+}
+
+func SetBpHandler(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req setBpReq
+
+		if !rest.ReadRESTReq(w, r, cliCtx.Codec, &req) {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, "failed to parse request")
+			return
+		}
+
+		baseReq := req.BaseReq.Sanitize()
+		if !baseReq.ValidateBasic(w) {
+			return
+		}
+
+		proposer, err := sdk.AccAddressFromBech32(req.Proposer)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		// create the message
+		msg := types.NewMsgSetBp(int64(req.FeeBp), int64(req.TransferBp), proposer)
+		err = msg.ValidateBasic()
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		utils.WriteGenerateStdTxResponse(w, cliCtx, baseReq, []sdk.Msg{msg})
+	}
+}

--- a/x/tax/genesis.go
+++ b/x/tax/genesis.go
@@ -1,0 +1,63 @@
+package tax
+
+import (
+	"errors"
+
+	"github.com/bluzelle/curium/x/tax/internal/keeper"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+type GenesisState struct {
+	Collector  sdk.AccAddress
+	FeeBp      int64
+	TransferBp int64
+}
+
+func NewGenesisState() GenesisState {
+	return GenesisState{}
+}
+
+func ValidateGenesis(data GenesisState) error {
+	if data.Collector.Empty() && data.FeeBp > 0 {
+		return errors.New("tax collector is empty but fee tax bp is not zero")
+	}
+	if data.Collector.Empty() && data.TransferBp > 0 {
+		return errors.New("tax collector is empty but transfer tax bp is not zero")
+	}
+	return nil
+}
+
+func DefaultGenesisState() GenesisState {
+	// $ blzcli keys add tax_owner --recover --keyring-backend=test
+	// address: bluzelle1wjkdcz4hl4gcarnqtupu7vkftal6h34qxjh6rw
+	// pubkey: bluzellepub1addwnpepq0r59990s6ljrucwnsf085p2lkugecf87gljr45cgalkfk623f88sr7re7n
+	// mnemonic: day rabbit mom clown bleak brown large lobster reduce accuse violin where address click dynamic myself buyer daughter situate today wheel thumb sudden drill
+	collector, err := sdk.AccAddressFromBech32("bluzelle1wjkdcz4hl4gcarnqtupu7vkftal6h34qxjh6rw")
+	if err != nil {
+		panic(err)
+	}
+	return GenesisState{
+		Collector:  collector,
+		FeeBp:      100,
+		TransferBp: 1,
+	}
+}
+
+func InitGenesis(ctx sdk.Context, k keeper.IKeeper, data GenesisState) []abci.ValidatorUpdate {
+	k.SetCollector(ctx, data.Collector)
+	k.SetFeeBp(ctx, data.FeeBp)
+	k.SetTransferBp(ctx, data.TransferBp)
+	return []abci.ValidatorUpdate{}
+}
+
+func ExportGenesis(ctx sdk.Context, k keeper.IKeeper) GenesisState {
+	collector := k.GetCollector(ctx)
+	feebp := k.GetFeeBp(ctx)
+	trfbp := k.GetTransferBp(ctx)
+	return GenesisState{
+		Collector:  collector,
+		FeeBp:      feebp,
+		TransferBp: trfbp,
+	}
+}

--- a/x/tax/genesis_test.go
+++ b/x/tax/genesis_test.go
@@ -1,0 +1,24 @@
+package tax
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGenesisState(t *testing.T) {
+	newGenesis := NewGenesisState()
+	require.True(t, newGenesis.Collector.Empty())
+	require.True(t, newGenesis.FeeBp == 0)
+	require.True(t, newGenesis.TransferBp == 0)
+}
+
+func TestValidateGenesis(t *testing.T) {
+	genesis := GenesisState{
+		FeeBp: 100, // 1.00%
+	}
+	require.Error(t, ValidateGenesis(genesis))
+}
+
+func TestInitGenesis(t *testing.T) {
+}

--- a/x/tax/handler.go
+++ b/x/tax/handler.go
@@ -1,0 +1,49 @@
+package tax
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/bluzelle/curium/x/tax/internal/keeper"
+	"github.com/bluzelle/curium/x/tax/internal/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+func NewHandler(keeper keeper.IKeeper) sdk.Handler {
+	return func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
+		switch msg := msg.(type) {
+		case types.MsgSetCollector:
+			return HandleMsgSetCollector(ctx, keeper, msg)
+		case types.MsgSetBp:
+			return HandleMsgSetBp(ctx, keeper, msg)
+		default:
+			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, fmt.Sprintf("Unrecognized tax msg type: %v", msg.Type()))
+		}
+	}
+}
+
+func HandleMsgSetCollector(ctx sdk.Context, keeper keeper.IKeeper, msg types.MsgSetCollector) (*sdk.Result, error) {
+	if err := msg.ValidateBasic(); err != nil {
+		return &sdk.Result{}, err
+	}
+	oldCollector := keeper.GetCollector(ctx)
+	if !bytes.Equal(msg.Proposer, oldCollector) {
+		return &sdk.Result{}, sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "proposer should be equal to original tax collector")
+	}
+	keeper.SetCollector(ctx, msg.NewCollector)
+	return &sdk.Result{}, nil
+}
+
+func HandleMsgSetBp(ctx sdk.Context, keeper keeper.IKeeper, msg types.MsgSetBp) (*sdk.Result, error) {
+	if err := msg.ValidateBasic(); err != nil {
+		return &sdk.Result{}, err
+	}
+	oldCollector := keeper.GetCollector(ctx)
+	if !bytes.Equal(msg.Proposer, oldCollector) {
+		return &sdk.Result{}, sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "proposer should be equal to original tax collector")
+	}
+	keeper.SetFeeBp(ctx, msg.NewFeeBp)
+	keeper.SetTransferBp(ctx, msg.NewTransferBp)
+	return &sdk.Result{}, nil
+}

--- a/x/tax/handler_test.go
+++ b/x/tax/handler_test.go
@@ -1,0 +1,71 @@
+package tax_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/bluzelle/curium/app"
+	"github.com/bluzelle/curium/x/tax"
+	"github.com/bluzelle/curium/x/tax/internal/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+func Test_handleMsgSetBp(t *testing.T) {
+	tApp := app.NewTestApp()
+	ctx := tApp.NewContext(true, abci.Header{})
+	tax.InitGenesis(ctx, tApp.GetTaxKeeper(), tax.DefaultGenesisState())
+
+	collector, err := sdk.AccAddressFromBech32("bluzelle1wjkdcz4hl4gcarnqtupu7vkftal6h34qxjh6rw")
+	if err != nil {
+		panic(err)
+	}
+
+	addr1 := sdk.AccAddress([]byte("my----------address1"))
+
+	// try setting Bp with correct owner
+	msg1 := types.NewMsgSetBp(11, 11, collector)
+	_, err = tax.HandleMsgSetBp(ctx, tApp.GetTaxKeeper(), msg1)
+	require.NoError(t, err)
+	feebp1 := tApp.GetTaxKeeper().GetFeeBp(ctx)
+	require.True(t, feebp1 == 11)
+	trfbp1 := tApp.GetTaxKeeper().GetTransferBp(ctx)
+	require.True(t, trfbp1 == 11)
+
+	// try setting Bp with incorrect owner
+	msg2 := types.NewMsgSetBp(12, 12, addr1)
+	_, err = tax.HandleMsgSetBp(ctx, tApp.GetTaxKeeper(), msg2)
+	require.Error(t, err)
+	feebp2 := tApp.GetTaxKeeper().GetFeeBp(ctx)
+	require.True(t, feebp2 == 11) // not changed
+	trfbp2 := tApp.GetTaxKeeper().GetTransferBp(ctx)
+	require.True(t, trfbp2 == 11) // not changed
+}
+
+func Test_handleMsgSetCollector(t *testing.T) {
+	tApp := app.NewTestApp()
+	ctx := tApp.NewContext(true, abci.Header{})
+	tax.InitGenesis(ctx, tApp.GetTaxKeeper(), tax.DefaultGenesisState())
+
+	collector, err := sdk.AccAddressFromBech32("bluzelle1wjkdcz4hl4gcarnqtupu7vkftal6h34qxjh6rw")
+	if err != nil {
+		panic(err)
+	}
+
+	addr1 := sdk.AccAddress([]byte("my----------address1"))
+
+	// try setting collector with incorrect owner
+	msg1 := types.NewMsgSetCollector(addr1, addr1)
+	_, err = tax.HandleMsgSetCollector(ctx, tApp.GetTaxKeeper(), msg1)
+	require.Error(t, err)
+	owner1 := tApp.GetTaxKeeper().GetCollector(ctx)
+	require.True(t, !bytes.Equal(owner1, addr1))
+
+	// try setting collector with correct owner
+	msg2 := types.NewMsgSetCollector(addr1, collector)
+	_, err = tax.HandleMsgSetCollector(ctx, tApp.GetTaxKeeper(), msg2)
+	require.NoError(t, err)
+	owner2 := tApp.GetTaxKeeper().GetCollector(ctx)
+	require.True(t, bytes.Equal(owner2, addr1))
+}

--- a/x/tax/internal/keeper/keeper.go
+++ b/x/tax/internal/keeper/keeper.go
@@ -1,0 +1,104 @@
+package keeper
+
+import (
+	"github.com/bluzelle/curium/x/tax/internal/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// IKeeper interface for this keeper
+type IKeeper interface {
+	GetCodec() *codec.Codec
+	SetCollector(ctx sdk.Context, collector sdk.AccAddress)
+	SetFeeBp(ctx sdk.Context, bp int64)
+	SetTransferBp(ctx sdk.Context, bp int64)
+	GetCollector(ctx sdk.Context) sdk.AccAddress
+	GetFeeBp(ctx sdk.Context) int64
+	GetTransferBp(ctx sdk.Context) int64
+	GetTaxInfo(ctx sdk.Context) types.TaxInfo
+}
+
+// constants
+var (
+	KeyCollector  = []byte("collector")
+	KeyFeeBp      = []byte("fee_bp")
+	KeyTransferBp = []byte("transfer_bp")
+)
+
+// Keeper manage storage for this module
+type Keeper struct {
+	storeKey sdk.StoreKey
+	cdc      *codec.Codec
+}
+
+// NewKeeper returns new instance of Keeper
+func NewKeeper(storeKey sdk.StoreKey, cdc *codec.Codec) Keeper {
+	return Keeper{
+		storeKey: storeKey,
+		cdc:      cdc,
+	}
+}
+
+// GetKVStore returns KVStore
+func (k Keeper) GetKVStore(ctx sdk.Context) sdk.KVStore {
+	return ctx.KVStore(k.storeKey)
+}
+
+// GetCodec returns keeper codec
+func (k Keeper) GetCodec() *codec.Codec {
+	return k.cdc
+}
+
+// SetCollector set collector
+func (k Keeper) SetCollector(ctx sdk.Context, collector sdk.AccAddress) {
+	store := k.GetKVStore(ctx)
+	store.Set(KeyCollector, k.cdc.MustMarshalBinaryBare(collector))
+}
+
+// GetCollector returns collector
+func (k Keeper) GetCollector(ctx sdk.Context) sdk.AccAddress {
+	store := k.GetKVStore(ctx)
+	var collector sdk.AccAddress
+	bz := store.Get(KeyCollector)
+	k.cdc.MustUnmarshalBinaryBare(bz, &collector)
+	return collector
+}
+
+// SetFeeBp set fee basis point
+func (k Keeper) SetFeeBp(ctx sdk.Context, bp int64) {
+	store := k.GetKVStore(ctx)
+	store.Set(KeyFeeBp, k.cdc.MustMarshalBinaryBare(bp))
+}
+
+// GetFeeBp returns fee basis point
+func (k Keeper) GetFeeBp(ctx sdk.Context) int64 {
+	store := k.GetKVStore(ctx)
+	var bp int64
+	bz := store.Get(KeyFeeBp)
+	k.cdc.MustUnmarshalBinaryBare(bz, &bp)
+	return bp
+}
+
+// SetTransferBp set fee basis point
+func (k Keeper) SetTransferBp(ctx sdk.Context, bp int64) {
+	store := k.GetKVStore(ctx)
+	store.Set(KeyTransferBp, k.cdc.MustMarshalBinaryBare(bp))
+}
+
+// GetTransferBp returns fee basis point
+func (k Keeper) GetTransferBp(ctx sdk.Context) int64 {
+	store := k.GetKVStore(ctx)
+	var bp int64
+	bz := store.Get(KeyTransferBp)
+	k.cdc.MustUnmarshalBinaryBare(bz, &bp)
+	return bp
+}
+
+// GetTaxInfo return tax info in a struct
+func (k Keeper) GetTaxInfo(ctx sdk.Context) types.TaxInfo {
+	return types.TaxInfo{
+		Collector:  k.GetCollector(ctx),
+		FeeBp:      k.GetFeeBp(ctx),
+		TransferBp: k.GetTransferBp(ctx),
+	}
+}

--- a/x/tax/internal/keeper/keeper_test.go
+++ b/x/tax/internal/keeper/keeper_test.go
@@ -1,0 +1,13 @@
+package keeper
+
+import (
+	"testing"
+)
+
+func TestKeeper_Collector(t *testing.T) {
+
+}
+
+func TestKeeper_Bp(t *testing.T) {
+
+}

--- a/x/tax/internal/keeper/querier.go
+++ b/x/tax/internal/keeper/querier.go
@@ -1,0 +1,32 @@
+package keeper
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+// constants
+const (
+	QueryTaxInfo = "tax_info"
+)
+
+// NewQuerier helps querying
+func NewQuerier(keeper IKeeper) sdk.Querier {
+	return func(ctx sdk.Context, path []string, req abci.RequestQuery) (res []byte, err error) {
+		switch path[0] {
+		case QueryTaxInfo:
+			return queryTaxInfo(ctx, keeper)
+		default:
+			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "unknown tax query endpoint")
+		}
+	}
+}
+
+func queryTaxInfo(ctx sdk.Context, keeper IKeeper) ([]byte, error) {
+	taxInfo := keeper.GetTaxInfo(ctx)
+
+	res, err := codec.MarshalJSONIndent(keeper.GetCodec(), taxInfo)
+	return res, err
+}

--- a/x/tax/internal/keeper/querier_test.go
+++ b/x/tax/internal/keeper/querier_test.go
@@ -1,0 +1,8 @@
+package keeper
+
+import (
+	"testing"
+)
+
+func Test_queryTaxInfo(t *testing.T) {
+}

--- a/x/tax/internal/types/codec.go
+++ b/x/tax/internal/types/codec.go
@@ -1,0 +1,18 @@
+package types
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+)
+
+// ModuleCdc is codec for this module
+var ModuleCdc = codec.New()
+
+func init() {
+	RegisterCodec(ModuleCdc)
+}
+
+// RegisterCodec register codecs for this module
+func RegisterCodec(cdc *codec.Codec) {
+	cdc.RegisterConcrete(MsgSetCollector{}, "tax/collector", nil)
+	cdc.RegisterConcrete(MsgSetBp{}, "tax/bp", nil)
+}

--- a/x/tax/internal/types/key.go
+++ b/x/tax/internal/types/key.go
@@ -1,0 +1,11 @@
+package types
+
+// keys for this module
+const (
+	// module name
+	ModuleName = "tax"
+
+	// StoreKey to be used when creating the KVStore
+	StoreKey  = ModuleName
+	RouterKey = ModuleName
+)

--- a/x/tax/internal/types/msg_collector.go
+++ b/x/tax/internal/types/msg_collector.go
@@ -1,0 +1,49 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+// MsgSetCollector defines a message to modify collector
+type MsgSetCollector struct {
+	NewCollector sdk.AccAddress
+	Proposer     sdk.AccAddress
+}
+
+// NewMsgSetCollector returns a new instance of MsgSetCollector
+func NewMsgSetCollector(newCollector, proposer sdk.AccAddress) MsgSetCollector {
+
+	return MsgSetCollector{
+		NewCollector: newCollector,
+		Proposer:     proposer,
+	}
+}
+
+// Route returns MsgSetCollector message route
+func (msg MsgSetCollector) Route() string { return RouterKey }
+
+// Type returns MsgSetCollector message type
+func (msg MsgSetCollector) Type() string { return "set_collector" }
+
+// ValidateBasic do basic validation for MsgSetCollector
+func (msg MsgSetCollector) ValidateBasic() error {
+	if msg.Proposer.Empty() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "proposer should not be empty address")
+	}
+	if msg.NewCollector.Empty() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "tax collector should not be empty address")
+	}
+
+	return nil
+}
+
+// GetSignBytes collect sign bytes from message
+func (msg MsgSetCollector) GetSignBytes() []byte {
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msg))
+}
+
+// GetSigners return signers of this message
+func (msg MsgSetCollector) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.Proposer}
+}

--- a/x/tax/internal/types/msg_collector_test.go
+++ b/x/tax/internal/types/msg_collector_test.go
@@ -1,0 +1,69 @@
+package types
+
+import (
+	"bytes"
+	"testing"
+
+	bluzellechain "github.com/bluzelle/curium/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	. "github.com/stretchr/testify/assert"
+)
+
+func GetTestAddresses(t *testing.T) []sdk.AccAddress {
+	addr1 := sdk.AccAddress([]byte("my----------address1"))
+	addr2 := sdk.AccAddress([]byte("my----------address2"))
+	return []sdk.AccAddress{addr1, addr2}
+}
+
+func TestNewMsgSetCollector(t *testing.T) {
+	addrs := GetTestAddresses(t)
+	proposer, newCollector := addrs[0], addrs[1]
+
+	msg := NewMsgSetCollector(newCollector, proposer)
+	True(t, bytes.Equal(msg.NewCollector.Bytes(), newCollector.Bytes()))
+	True(t, bytes.Equal(msg.Proposer.Bytes(), proposer.Bytes()))
+}
+
+func TestMsgSetCollector_Route(t *testing.T) {
+	Equal(t, MsgSetCollector{}.Route(), RouterKey)
+}
+
+func TestMsgSetCollector_Type(t *testing.T) {
+	Equal(t, MsgSetCollector{}.Type(), "set_collector")
+}
+
+func TestMsgSetCollector_ValidateBasic(t *testing.T) {
+	addrs := GetTestAddresses(t)
+	proposer, newCollector := addrs[0], addrs[1]
+
+	msg := NewMsgSetCollector(newCollector, proposer)
+	err := msg.ValidateBasic()
+	True(t, err == nil)
+
+	msg = NewMsgSetCollector(sdk.AccAddress{}, proposer)
+	err = msg.ValidateBasic()
+	True(t, err != nil)
+	Equal(t, err.Error(), "invalid address: tax collector should not be empty address")
+
+	msg = NewMsgSetCollector(newCollector, sdk.AccAddress{})
+	err = msg.ValidateBasic()
+	True(t, err != nil)
+	Equal(t, err.Error(), "invalid address: proposer should not be empty address")
+}
+
+func TestMsgSetCollector_GetSignBytes(t *testing.T) {
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount(bluzellechain.Bech32PrefixAccAddr, bluzellechain.Bech32PrefixAccPub)
+
+	addrs := GetTestAddresses(t)
+	proposer, newCollector := addrs[0], addrs[1]
+	msg := NewMsgSetCollector(newCollector, proposer)
+	Equal(t, string(msg.GetSignBytes()), `{"type":"tax/collector","value":{"NewCollector":"bluzelle1d4uj6tfd95kj6tfd95kkzerywfjhxuejgs5ltx","Proposer":"bluzelle1d4uj6tfd95kj6tfd95kkzerywfjhxue3xrpf9e"}}`)
+}
+
+func TestMsgSetCollector_GetSigners(t *testing.T) {
+	addrs := GetTestAddresses(t)
+	proposer, newCollector := addrs[0], addrs[1]
+	msg := NewMsgSetCollector(newCollector, proposer)
+	Equal(t, msg.GetSigners(), []sdk.AccAddress{proposer})
+}

--- a/x/tax/internal/types/msg_percentage.go
+++ b/x/tax/internal/types/msg_percentage.go
@@ -1,0 +1,59 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+// MsgSetBp defines a message to modify collector
+type MsgSetBp struct {
+	NewFeeBp      int64
+	NewTransferBp int64
+	Proposer      sdk.AccAddress
+}
+
+// NewMsgSetBp returns a new instance of MsgSetBp
+func NewMsgSetBp(newFeeBp int64, newTransferBp int64, proposer sdk.AccAddress) MsgSetBp {
+	return MsgSetBp{
+		NewTransferBp: newTransferBp,
+		NewFeeBp:      newFeeBp,
+		Proposer:      proposer,
+	}
+}
+
+// Route returns MsgSetBp message route
+func (msg MsgSetBp) Route() string { return RouterKey }
+
+// Type returns MsgSetBp message type
+func (msg MsgSetBp) Type() string { return "set_bp" }
+
+// ValidateBasic do basic validation for MsgSetBp
+func (msg MsgSetBp) ValidateBasic() error {
+	if msg.Proposer.Empty() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "proposer should not be empty address")
+	}
+	if msg.NewFeeBp < 0 {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "tax should not be negative")
+	}
+	if msg.NewFeeBp > 10000 {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "tax should not exceed 10000 bp")
+	}
+	if msg.NewTransferBp < 0 {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "tax should not be negative")
+	}
+	if msg.NewTransferBp > 10000 {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "tax should not exceed 10000 bp")
+	}
+
+	return nil
+}
+
+// GetSignBytes collect sign bytes from message
+func (msg MsgSetBp) GetSignBytes() []byte {
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msg))
+}
+
+// GetSigners return signers of this message
+func (msg MsgSetBp) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.Proposer}
+}

--- a/x/tax/internal/types/types.go
+++ b/x/tax/internal/types/types.go
@@ -1,0 +1,10 @@
+package types
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+// TaxInfo is struct for tax querying
+type TaxInfo struct {
+	Collector  sdk.AccAddress
+	FeeBp      int64
+	TransferBp int64
+}

--- a/x/tax/internal/types/types_test.go
+++ b/x/tax/internal/types/types_test.go
@@ -1,0 +1,1 @@
+package types

--- a/x/tax/module.go
+++ b/x/tax/module.go
@@ -1,0 +1,108 @@
+package tax
+
+import (
+	"encoding/json"
+
+	"github.com/bluzelle/curium/x/tax/client/cli"
+	"github.com/bluzelle/curium/x/tax/client/rest"
+	"github.com/bluzelle/curium/x/tax/internal/types"
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/gorilla/mux"
+	"github.com/spf13/cobra"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+var (
+	_ module.AppModule      = AppModule{}
+	_ module.AppModuleBasic = AppModuleBasic{}
+)
+
+type AppModuleBasic struct{}
+
+func (AppModuleBasic) Name() string {
+	return types.ModuleName
+}
+
+func (AppModuleBasic) RegisterCodec(cdc *codec.Codec) {
+	RegisterCodec(cdc)
+}
+
+func (AppModuleBasic) DefaultGenesis() json.RawMessage {
+	return ModuleCdc.MustMarshalJSON(DefaultGenesisState())
+}
+
+func (AppModuleBasic) ValidateGenesis(bz json.RawMessage) error {
+	var data GenesisState
+	err := ModuleCdc.UnmarshalJSON(bz, &data)
+	if err != nil {
+		return err
+	}
+	return ValidateGenesis(data)
+}
+
+func (AppModuleBasic) RegisterRESTRoutes(ctx context.CLIContext, rtr *mux.Router) {
+	rest.RegisterRoutes(ctx, rtr, StoreKey)
+}
+
+func (AppModuleBasic) GetQueryCmd(cdc *codec.Codec) *cobra.Command {
+	return cli.GetQueryCmd(StoreKey, cdc)
+}
+
+func (AppModuleBasic) GetTxCmd(cdc *codec.Codec) *cobra.Command {
+	return cli.GetTxCmd(StoreKey, cdc)
+}
+
+type AppModule struct {
+	AppModuleBasic
+	keeper Keeper
+}
+
+func NewAppModule(k Keeper) AppModule {
+
+	return AppModule{
+		AppModuleBasic: AppModuleBasic{},
+		keeper:         k,
+	}
+}
+
+func (AppModule) Name() string {
+	return ModuleName
+}
+
+func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
+
+func (am AppModule) Route() string {
+	return RouterKey
+}
+
+func (am AppModule) NewHandler() sdk.Handler {
+	return NewHandler(am.keeper)
+}
+
+func (am AppModule) QuerierRoute() string {
+	return ModuleName
+}
+
+func (am AppModule) NewQuerierHandler() sdk.Querier {
+	return NewQuerier(am.keeper)
+}
+
+func (am AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
+
+func (am AppModule) EndBlock(sdk.Context, abci.RequestEndBlock) []abci.ValidatorUpdate {
+	return []abci.ValidatorUpdate{}
+}
+
+func (am AppModule) InitGenesis(ctx sdk.Context, data json.RawMessage) []abci.ValidatorUpdate {
+	var genesisState GenesisState
+	ModuleCdc.MustUnmarshalJSON(data, &genesisState)
+	return InitGenesis(ctx, am.keeper, genesisState)
+}
+
+func (am AppModule) ExportGenesis(ctx sdk.Context) json.RawMessage {
+	gs := ExportGenesis(ctx, am.keeper)
+	return ModuleCdc.MustMarshalJSON(gs)
+}

--- a/x/tax/module_test.go
+++ b/x/tax/module_test.go
@@ -1,0 +1,126 @@
+package tax
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	bluzellechain "github.com/bluzelle/curium/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppModuleBasic_Name(t *testing.T) {
+	sut := AppModuleBasic{}
+	assert.Equal(t, sut.Name(), "tax")
+}
+
+func TestAppModuleBasic_DefaultGenesis(t *testing.T) {
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount(bluzellechain.Bech32PrefixAccAddr, bluzellechain.Bech32PrefixAccPub)
+	genesis := AppModuleBasic{}.DefaultGenesis()
+	assert.NotNil(t, genesis)
+	assert.Equal(t, string(genesis), `{"Collector":"bluzelle1wjkdcz4hl4gcarnqtupu7vkftal6h34qxjh6rw","FeeBp":"100","TransferBp":"1"}`)
+}
+
+func TestAppModuleBasic_ValidateGenesis(t *testing.T) {
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount(bluzellechain.Bech32PrefixAccAddr, bluzellechain.Bech32PrefixAccPub)
+
+	bz := json.RawMessage{}
+	err := AppModuleBasic.ValidateGenesis(AppModuleBasic{}, bz)
+	if err == nil {
+		t.Error("ValidateGenesis did not return an error for an empty genesis file")
+	} else if err.Error() != "UnmarshalJSON cannot decode empty bytes" {
+		t.Errorf("ValidateGenesis returned err - %s:%s", err, err.Error())
+	}
+
+	bz = AppModuleBasic{}.DefaultGenesis()
+	err = AppModuleBasic.ValidateGenesis(AppModuleBasic{}, bz)
+	assert.Nil(t, err)
+}
+
+func TestAppModuleBasic_GetQueryCmd(t *testing.T) {
+	cdc := codec.Codec{}
+	command := AppModuleBasic{}.GetQueryCmd(&cdc)
+
+	if command == nil {
+		t.Error("GetQueryCmd function returned nil")
+	} else {
+		assert.Equal(t, command.Use, "tax")
+		assert.Equal(t, command.Short, "Querying commands for the tax module")
+		assert.True(t, command.DisableFlagParsing)
+		assert.Equal(t, command.SuggestionsMinimumDistance, 0)
+
+		sf1 := reflect.ValueOf(command.RunE)
+		sf2 := reflect.ValueOf(client.ValidateCmd)
+		assert.Equal(t, sf1, sf2)
+	}
+}
+
+func TestAppModuleBasic_GetQueryCmd_TaxQueries(t *testing.T) {
+	cdc := codec.Codec{}
+	command := AppModuleBasic{}.GetQueryCmd(&cdc)
+
+	commands := command.Commands()
+	assert.Len(t, command.Commands(), 1)
+
+	expectedUses := [...]string{"info"}
+	expectedNames := [...]string{"info"}
+
+	for i := 0; i < len(command.Commands()); i++ {
+		expectedUse := expectedUses[i]
+		expectedName := expectedNames[i]
+		cmd := commands[i]
+		assert.Equal(t, expectedUse, cmd.Use)
+		assert.Equal(t, expectedName, cmd.Name())
+	}
+}
+
+func TestAppModuleBasic_GetTxCmd(t *testing.T) {
+	cdc := codec.Codec{}
+	sut := AppModuleBasic{}
+	cmd := sut.GetTxCmd(&cdc)
+
+	if nil == cmd {
+		t.Error("GetTxCmd method returned nil")
+	} else {
+		assert.Equal(t, "tax", cmd.Use)
+		assert.Equal(t, "func(*cobra.Command, []string) error", reflect.TypeOf(client.ValidateCmd).String())
+		assert.Equal(t, 2, cmd.SuggestionsMinimumDistance)
+
+		commands := cmd.Commands()
+		assert.Len(t, commands, 2)
+	}
+}
+
+func TestNewAppModule(t *testing.T) {
+	k := Keeper{}
+	sut := NewAppModule(k)
+
+	assert.Equal(t, "tax", sut.Route())
+}
+
+func TestAppModule_Name(t *testing.T) {
+	k := Keeper{}
+	sut := NewAppModule(k)
+
+	assert.Equal(t, "tax", sut.Name())
+}
+
+func TestAppModule_Route(t *testing.T) {
+
+}
+
+func TestAppModule_QuerierRoute(t *testing.T) {
+	sut := AppModule{}
+	assert.Equal(t, "tax", sut.QuerierRoute())
+}
+
+func TestAppModule_NewQuerierHandler(t *testing.T) {
+	sut := AppModule{}
+	querier := sut.NewQuerierHandler()
+	assert.Equal(t, "func(types.Context, []string, types.RequestQuery) ([]uint8, error)", reflect.TypeOf(querier).String())
+}


### PR DESCRIPTION
address initialize in general

wrong codebase modification

add basic readme

modify wrong NewAppModule initialization on test

fix build errors for ante and add ante handler connection to app

fix ante handler panic issue, add genesis account, local setup script

fix query tax info

test blzcli tx setpercentage/setcollector and fix

fix existing go test and add command/readme for tax module test

add readme for tax module test

For the set functions, we should make sure they are consistent with COSMOS naming conventions.

set small percentage unit basis_point 0.0001 as unit

Add tests for handlers

add transfer_fee_bp

implement bank send fee

update readme

set default transfer tax to 0.01% and update TrfBp to TransferBp

add tx send command as well for testing

add more comments

add 4 negatives testing commands

fix build error after rebase

fix insufficient funds: invalid coins: 0ubnt

update readme

handle feeTax empty case